### PR TITLE
fixed the font size in editor view

### DIFF
--- a/tikz_editor/views/editor.py
+++ b/tikz_editor/views/editor.py
@@ -141,6 +141,8 @@ class EditorView(QsciScintilla):
 	def loadUserPreferences(self):
 		# editor font
 		font = Preferences.getEditorFont()
+		font.setPointSize(12)
+
 		self.setFont(font)
 		lexer = LexerTikZ()
 		lexer.setDefaultFont(font)


### PR DESCRIPTION
On Linux the font size in the editor was showing too small hence added the font size of 12 by default that would work on all operating systems.