### PR TITLE
fixed argument type for singleShot

### DIFF
--- a/tikz_editor/controllers/preview.py
+++ b/tikz_editor/controllers/preview.py
@@ -83,7 +83,7 @@ class PreviewController(QObject):
 		if elapsed_ms >= preview_threshold:
 			self.updatePreview()
 		else:
-			wait_for = max(100, Preferences.getPreviewThreshold() / 2)
+			wait_for = int(max(100, Preferences.getPreviewThreshold() / 2))
 			QTimer.singleShot(wait_for, self.updatePreviewAfterTypingPause)
 
 	def updatePreview(self):


### PR DESCRIPTION
Without explicit conversion the error is reported:
```
TypeError: arguments did not match any overloaded call:
  singleShot(msec: int, slot: PYQT_SLOT): argument 1 has unexpected type 'float'
  singleShot(msec: int, timerType: Qt.TimerType, slot: PYQT_SLOT): argument 1 has unexpected type 'float'
```